### PR TITLE
Voting no long effects block gas limit

### DIFF
--- a/ethereum/messages.py
+++ b/ethereum/messages.py
@@ -241,8 +241,6 @@ def apply_casper_vote_transaction(state, tx):
         output = bytearray_to_bytestr(data)
         success = 1
 
-    state.gas_used += gas_used
-
     # Pre-Metropolis: commit state after every tx
     if not state.is_METROPOLIS() and not SKIP_MEDSTATES:
         state.commit()

--- a/ethereum/tests/hybrid_casper/test_chain.py
+++ b/ethereum/tests/hybrid_casper/test_chain.py
@@ -109,10 +109,13 @@ def test_no_gas_cost_for_successful_casper_vote(db):
     test = TestLangHybrid(15, 100, 0.02, 0.002)
     test.parse(test_string)
     pre_balance = test.t.head_state.get_balance(sender)
+    pre_block_gas_used = test.t.head_state.gas_used
     test_string = 'V0'
     test.parse(test_string)
     post_balance = test.t.head_state.get_balance(sender)
+    post_block_gas_used = test.t.head_state.gas_used
     assert pre_balance == post_balance
+    assert pre_block_gas_used == post_block_gas_used
 
 
 def test_costs_gas_for_failed_casper_vote(db):


### PR DESCRIPTION
Delete `state.gas_used += gas_used` in `message.py` so that voting will no longer have an impact on the block gas limit.