### PR TITLE
Fixed tests_require that needs list instead of set

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ install_requires = [
         r, r) for r in install_requires]
 
 # dev requirements
-tests_require = set(x.strip() for x in open('dev_requirements.txt'))
+tests_require = list(set(x.strip() for x in open('dev_requirements.txt')))
 
 # dependency links
 dependency_links = []


### PR DESCRIPTION
### What was wrong?

error in ethereum setup command: 'tests_require' must be a string or list of strings containing valid project/version requirement specifiers; Unordered types are not allowed